### PR TITLE
fix external linkage error in BRepBuilderAPI_Copy

### DIFF
--- a/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx
@@ -25,8 +25,6 @@
 #include <gp_Pnt.hxx>
 #include <Poly_Triangulation.hxx>
 
-namespace {
-
 //! Tool class implementing necessary functionality for copying geometry
 class BRepBuilderAPI_Copy_Modification : public BRepTools_Modification 
 {
@@ -146,8 +144,6 @@ private:
 DEFINE_STANDARD_HANDLE(BRepBuilderAPI_Copy_Modification, BRepTools_Modification)
 IMPLEMENT_STANDARD_HANDLE(BRepBuilderAPI_Copy_Modification, BRepTools_Modification)
 IMPLEMENT_STANDARD_RTTIEXT(BRepBuilderAPI_Copy_Modification, BRepTools_Modification)
-
-} // anonymous namespace
 
 //=======================================================================
 //function : BRepBuilderAPI_Copy


### PR DESCRIPTION
This patch fixed the following error I get compiling with https://github.com/mxe/mxe
```
[ 23%] Building CXX object adm/cmake/TKTopAlgo/CMakeFiles/TKTopAlgo.dir/__/__/__/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx.obj
In file included from [...]/inc/Handle_TopoDS_TShape.hxx:10:0,
                 from [...]/inc/TopoDS_Shape.hxx:13,
                 from [...]/drv/BRepBuilderAPI/BRepBuilderAPI_Copy.jxx:1,
                 from [...]/drv/BRepBuilderAPI/BRepBuilderAPI_Copy.ixx:6,
                 from [...]/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx:17:
[...]/src/Standard/Standard_DefineHandle.hxx:94:54: error: external linkage required for symbol 'const Handle_Standard_Type& {anonymous}::BRepBuilderAPI_Copy_Modification::DynamicType() const' because of 'dllexport' attribute
 Standard_EXPORT virtual const Handle(Standard_Type)& DynamicType() const;
                                                      ^
[...]/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx:139:3: note: in expansion of macro 'DEFINE_STANDARD_RTTI'
   DEFINE_STANDARD_RTTI(BRepBuilderAPI_Copy_Modification)
   ^~~~~~~~~~~~~~~~~~~~
[...]/src/Standard/Standard_DefineHandle.hxx:76:37: error: external linkage required for symbol 'static {anonymous}::Handle_BRepBuilderAPI_Copy_Modification {anonymous}::Handle_BRepBuilderAPI_Copy_Modification::DownCast(const Handle_Standard_Transient&)' because of 'dllexport' attribute
   Standard_EXPORT static Handle(C1) DownCast(const Handle(BC)& AnObject); \
                                     ^
[...]/src/Standard/Standard_DefineHandle.hxx:81:39: note: in expansion of macro 'DEFINE_STANDARD_HANDLECLASS'
 #define DEFINE_STANDARD_HANDLE(C1,C2) DEFINE_STANDARD_HANDLECLASS(C1,C2,Standard_Transient)
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
[...]/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx:146:1: note: in expansion of macro 'DEFINE_STANDARD_HANDLE'
 DEFINE_STANDARD_HANDLE(BRepBuilderAPI_Copy_Modification, BRepTools_Modification)
 ^~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [adm/cmake/TKTopAlgo/CMakeFiles/TKTopAlgo.dir/build.make:4339: adm/cmake/TKTopAlgo/CMakeFiles/TKTopAlgo.dir/__/__/__/src/BRepBuilderAPI/BRepBuilderAPI_Copy.cxx.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:1420: adm/cmake/TKTopAlgo/CMakeFiles/TKTopAlgo.dir/all] Error 2
make: *** [Makefile:163: all] Error 2
```